### PR TITLE
object no longer created when checking for existence of api key closes #41

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -7,8 +7,7 @@ module Api
 
       private
         def restrict_access
-          api_key = ApiKey.find_by(api_key: params[:api_key])
-          head :unauthorized unless api_key
+          head :unauthorized unless ApiKey.exists?(api_key: params[:api_key])
         end
     end
   end


### PR DESCRIPTION
using exists instead of find by when checking existence of api key in api controller